### PR TITLE
[Symfony 3] Using CacheConfig throws exception

### DIFF
--- a/Translation/CacheManager.php
+++ b/Translation/CacheManager.php
@@ -40,7 +40,7 @@ class CacheManager
             return false;
         }
         $messageCollection = new MessageCollection();
-        $messageCollection->import(include $cache);
+        $messageCollection->import(include $filename);
         return $messageCollection;
     }
 


### PR DESCRIPTION
Starting Symfony 3, CacheConfig doesn't have a __toString() function.

Until Symfony 2, CacheConfig::__toString returns the Filename
Starting Symfony 3, trying to convert CacheConfig to string throws an Exception