### PR TITLE
YAML Symfony 3 compliant

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,19 +1,20 @@
 domis86_translator_translator_save_message:
     path: /save_message
-    defaults: { _controller: domis86_translator.controller.translator_controller:saveMessageAction }
-
+    defaults:
+        _controller: 'domis86_translator.controller.translator_controller:saveMessageAction'
 domis86_translator_translator_delete_message:
     path: /delete_message
-    defaults: { _controller: domis86_translator.controller.translator_controller:deleteMessageAction }
-
+    defaults:
+        _controller: 'domis86_translator.controller.translator_controller:deleteMessageAction'
 domis86_translator_translator_backend:
     path: /backend
-    defaults: { _controller: domis86_translator.controller.translator_controller:backendAction }
-
+    defaults:
+        _controller: 'domis86_translator.controller.translator_controller:backendAction'
 domis86_translator_translator_backend_clear_cache:
     path: /backend/clearcache
-    defaults: { _controller: domis86_translator.controller.translator_controller:clearCacheAction }
-
+    defaults:
+        _controller: 'domis86_translator.controller.translator_controller:clearCacheAction'
 domis86_translator_translator_backend_clear_untranslated_messages:
     path: /backend/clear_untranslated_messages
-    defaults: { _controller: domis86_translator.controller.translator_controller:clearUntranslatedMessagesAction }
+    defaults:
+        _controller: 'domis86_translator.controller.translator_controller:clearUntranslatedMessagesAction'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,65 +2,73 @@ parameters:
     domis86_translator.translator.class: Domis86\TranslatorBundle\Translation\Translator
     domis86_translator.controller.translator_controller.class: Domis86\TranslatorBundle\Controller\TranslatorController
     domis86_translator.data_collector.class: Domis86\TranslatorBundle\DataCollector\TranslatorDataCollector
-
 services:
-
-# public
-
     domis86_translator.translator:
         class: '%domis86_translator.translator.class%'
-        arguments: [@domis86_translator.message_manager, @translator.selector, %domis86_translator.ignored_domains%]
-
+        arguments:
+            - '@domis86_translator.message_manager'
+            - '@translator.selector'
+            - '%domis86_translator.ignored_domains%'
     domis86_translator.controller.translator_controller:
         class: '%domis86_translator.controller.translator_controller.class%'
-        arguments: [@templating, @domis86_translator.web_debug_dialog, %domis86_translator.config%, @translator, @translation.writer]
-
-# private
-
+        arguments:
+            - '@templating'
+            - '@domis86_translator.web_debug_dialog'
+            - '%domis86_translator.config%'
+            - '@translator'
+            - '@translation.writer'
     domis86_translator.message_manager:
         public: false
         class: Domis86\TranslatorBundle\Translation\MessageManager
         arguments:
-            - @domis86_translator.storage
-            - @domis86_translator.cache_manager
-            - @domis86_translator.message_verifier
-
+            - '@domis86_translator.storage'
+            - '@domis86_translator.cache_manager'
+            - '@domis86_translator.message_verifier'
     domis86_translator.web_debug_dialog:
         public: false
         class: Domis86\TranslatorBundle\Translation\WebDebugDialog
-        arguments: [@domis86_translator.storage, @domis86_translator.cache_manager, @domis86_translator.message_verifier, %domis86_translator.managed_locales%]
-
+        arguments:
+            - '@domis86_translator.storage'
+            - '@domis86_translator.cache_manager'
+            - '@domis86_translator.message_verifier'
+            - '%domis86_translator.managed_locales%'
     domis86_translator.message_verifier:
         public: false
         class: Domis86\TranslatorBundle\Translation\NamingVerifier
         arguments:
-            - %domis86_translator.managed_locales%
-
+            - '%domis86_translator.managed_locales%'
     domis86_translator.storage:
         public: false
         class: Domis86\TranslatorBundle\Storage\Storage
-        arguments: [@doctrine.orm.entity_manager]
-
+        arguments:
+            - '@doctrine.orm.entity_manager'
     domis86_translator.cache_manager:
         public: false
         class: Domis86\TranslatorBundle\Translation\CacheManager
         arguments:
-            - %kernel.cache_dir%/domis86translator
-            - %kernel.debug%
-
-
-# listeners - tags set in Domis86\TranslatorBundle\DependencyInjection\Extension
-
+            - '%kernel.cache_dir%/domis86translator'
+            - '%kernel.debug%'
     domis86_translator.controller_listener:
         public: false
         class: Domis86\TranslatorBundle\EventListener\TranslatorControllerListener
-        arguments: [@domis86_translator.message_manager, @translator, %domis86_translator.whitelisted_controllers_regexes%, %domis86_translator.ignored_controllers_regexes%]
+        arguments:
+            - '@domis86_translator.message_manager'
+            - '@domis86_translator.translator'
+            - '%domis86_translator.whitelisted_controllers_regexes%'
+            - '%domis86_translator.ignored_controllers_regexes%'
     domis86_translator.response_listener:
         public: false
         class: Domis86\TranslatorBundle\EventListener\TranslatorResponseListener
-        arguments: [@domis86_translator.message_manager, @templating, %domis86_translator.config%, @translator]
-        scope: request
+        arguments:
+            - '@domis86_translator.message_manager'
+            - '@templating'
+            - '%domis86_translator.config%'
+            - '@domis86_translator.translator'
     domis86_translator.command_listener:
         public: false
         class: Domis86\TranslatorBundle\EventListener\TranslatorConsoleListener
-        arguments: [@domis86_translator.message_manager, @translator, %domis86_translator.whitelisted_controllers_regexes%, %domis86_translator.ignored_controllers_regexes%]
+        arguments:
+            - '@domis86_translator.message_manager'
+            - '@domis86_translator.translator'
+            - '%domis86_translator.whitelisted_controllers_regexes%'
+            - '%domis86_translator.ignored_controllers_regexes%'

--- a/Resources/config/services_dev.yml
+++ b/Resources/config/services_dev.yml
@@ -1,1 +1,1 @@
-services:
+services: null


### PR DESCRIPTION
Corrected by https://github.com/umpirsky/Symfony-Upgrade-Fixer + https://github.com/umpirsky/Symfony-Upgrade-Fixer/pull/18 for YAML plugin)

I've got a modified version of this bundle which works on Symfony 3.4.
I think that this PR makes the Bundle compliant with Symfony 3 but i've haven't tested this version...